### PR TITLE
Change lineEditLiveId validator to alphanumeric

### DIFF
--- a/src/UI/WindowMain.cpp
+++ b/src/UI/WindowMain.cpp
@@ -101,7 +101,7 @@ WindowMain::WindowMain(QWidget* parent) :
     ui.tableWidget->setSelectionMode(QAbstractItemView::SingleSelection);
     ui.tableWidget->setEditTriggers(QAbstractItemView::DoubleClicked);
 
-    ui.lineEditLiveId->setValidator(new QRegularExpressionValidator(QRegularExpression("[0-9]+$"), this));
+    ui.lineEditLiveId->setValidator(new QRegularExpressionValidator(QRegularExpression("[A-Za-z0-9]+$"), this));
     ui.lineEditLiveId->setClearButtonEnabled(true);
 
     configinitload.start();


### PR DESCRIPTION
根据 #45 #117 等若干issue反馈，抖音直播间的监控存在一定的问题，且问题可以稳定复现。具体表现为，使用默认方法获取到的抖音直播间RID在开启监控后一段时间即提示直播中断，且在未中断时即便直播流中出现了二维码也不会进行扫码操作。根据 #45 中的记录，有用户在使用抖音号替代默认直播的RID后成功完成抢码。

将正则表达式改为字母和数字以适配抖音直播间的抖音号可能包含字母